### PR TITLE
Allow symfony 3+

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.3.2",
-        "symfony/symfony": "~2.1",
+        "symfony/symfony": ">2.1",
         "snc/redis-bundle": "*"
     },
     "autoload": {


### PR DESCRIPTION
I ran the deprecation checker against this, none found. Need this to allow 3+ for an update to 3 for the main repo.